### PR TITLE
Potential fix for code scanning alert no. 20: File is not always closed

### DIFF
--- a/scripts/release/dolibarr_release.py
+++ b/scripts/release/dolibarr_release.py
@@ -167,26 +167,28 @@ class DolibarrReleaser:
         try:
             # SHA256
             sha256_path = zip_path.with_suffix(zip_path.suffix + '.sha256')
-            subprocess.run(
-                ['sha256sum', zip_path.name],
-                cwd=zip_path.parent,
-                check=True,
-                capture_output=True,
-                text=True,
-                stdout=open(sha256_path, 'w')
-            )
+            with open(sha256_path, 'w') as sha256_file:
+                subprocess.run(
+                    ['sha256sum', zip_path.name],
+                    cwd=zip_path.parent,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    stdout=sha256_file
+                )
             print(f"✅ Generated SHA256 checksum")
 
             # MD5
             md5_path = zip_path.with_suffix(zip_path.suffix + '.md5')
-            subprocess.run(
-                ['md5sum', zip_path.name],
-                cwd=zip_path.parent,
-                check=True,
-                capture_output=True,
-                text=True,
-                stdout=open(md5_path, 'w')
-            )
+            with open(md5_path, 'w') as md5_file:
+                subprocess.run(
+                    ['md5sum', zip_path.name],
+                    cwd=zip_path.parent,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    stdout=md5_file
+                )
             print(f"✅ Generated MD5 checksum")
             
             return True


### PR DESCRIPTION
Potential fix for [https://github.com/mokoconsulting-tech/MokoStandards/security/code-scanning/20](https://github.com/mokoconsulting-tech/MokoStandards/security/code-scanning/20)

To fix the problem, the file objects used as `stdout` for `subprocess.run` should be explicitly and reliably closed. The idiomatic way in Python is to use a `with open(...) as f:` context manager around each `subprocess.run` call so that the file is closed even if an exception is raised. This avoids manual `try/finally` bookkeeping while not changing the functional behavior of the script.

Concretely, in `DolibarrReleaser.generate_checksums`, replace the inline `stdout=open(sha256_path, 'w')` and `stdout=open(md5_path, 'w')` arguments with context-managed file handles. For each checksum type, open the output file in a `with` block, call `subprocess.run` with `stdout=f`, and let the context manager close the file automatically. Keep all existing arguments (`cwd`, `check`, `capture_output`, `text`) and logging statements unchanged. No new imports are needed, and no behavior (output paths, command line, return values) changes except ensuring that the files are always closed correctly.

All changes are within `scripts/release/dolibarr_release.py` in the `generate_checksums` method around lines 165–189.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
