### PR TITLE
Potential fix for code scanning alert no. 9: Empty except

### DIFF
--- a/scripts/docs/rebuild_indexes.py
+++ b/scripts/docs/rebuild_indexes.py
@@ -72,8 +72,9 @@ def get_immediate_children(folder_path: Path) -> Tuple[List[Path], List[Path]]:
                 child_folders.append(item)
             elif item.is_file() and item.suffix == '.md' and item.name != INDEX_FILENAME:
                 child_files.append(item)
-    except PermissionError:
-        pass
+    except PermissionError as exc:
+        # Intentionally skip folders we cannot read; log for diagnostics.
+        print(f"Warning: cannot access directory '{folder_path}': {exc}", file=sys.stderr)
     
     # Sort alphabetically for deterministic output
     child_folders.sort(key=lambda p: p.name.lower())


### PR DESCRIPTION
Potential fix for [https://github.com/mokoconsulting-tech/MokoStandards/security/code-scanning/9](https://github.com/mokoconsulting-tech/MokoStandards/security/code-scanning/9)

In general, to fix an empty `except` block, you either (a) handle the exception meaningfully (log it, transform it, clean up, or propagate), or (b) clearly document why it is safe to ignore, usually with a comment and optionally a debug/trace log. The goal is to avoid silent, unexplained swallowing of exceptions.

For this script, the best fix that preserves existing functionality is to keep the behavior of skipping unreadable directories while adding a brief explanatory comment and a low-impact diagnostic message to `stderr`. That way, if some folders are skipped due to permissions, a user or CI log will show what happened, but the function continues to return whatever it can read. We do this entirely inside `get_immediate_children` around the `except PermissionError:` block. No new imports are needed: we already import `sys`, and `print(..., file=sys.stderr)` is standard.

Concretely:
- In `scripts/docs/rebuild_indexes.py`, around lines 69–76, replace the empty `except PermissionError: pass` with an `except PermissionError as exc:` that:
  - Adds a short comment explaining that unreadable directories are intentionally skipped.
  - Prints a concise warning to `stderr` including the folder path and error message.
- Leave the rest of the function unchanged so sorting and return values are identical.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
