### PR TITLE
Fix for Unused import

### DIFF
--- a/scripts/analyze_pr_conflicts.py
+++ b/scripts/analyze_pr_conflicts.py
@@ -9,7 +9,7 @@ with the main branch and provides specific guidance for resolving them.
 import subprocess
 import json
 import sys
-from typing import List, Dict, Optional
+from typing import List, Dict
 
 def run_command(cmd: List[str]) -> tuple[int, str, str]:
     """Run a command and return exit code, stdout, stderr."""


### PR DESCRIPTION
In general, unused-import issues are fixed by either removing the unused import or updating the code to actually use it if it was mistakenly omitted from annotations. Here, there are no annotations that obviously should be `Optional[...]`, so the safest change that preserves existing functionality is to remove `Optional` from the import list.

Concretely, in `scripts/analyze_pr_conflicts.py`, at line 12, change `from typing import List, Dict, Optional` to only import the types that are actually used: `from typing import List, Dict`. No other changes are needed. This does not alter runtime behavior because `typing` is only used for type hints.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._